### PR TITLE
phoenix.c: added #define _GNU_SOURCE

### DIFF
--- a/src/phoenix.c
+++ b/src/phoenix.c
@@ -17,6 +17,8 @@
  * the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#define _GNU_SOURCE		/* memmem is useful */
+
 #include <stdio.h>
 #include <inttypes.h>
 #include <string.h>


### PR DESCRIPTION
This change supresses a compiler warning for memmem in phoenix.c